### PR TITLE
hotfix: adicionar demonstração urgente para badge YOLO

### DIFF
--- a/YOLO-DEMO.md
+++ b/YOLO-DEMO.md
@@ -1,0 +1,50 @@
+# 🎲 YOLO Badge Demonstration
+
+## 🚨 HOTFIX URGENTE
+
+Este arquivo foi criado para demonstrar a conquista da badge YOLO através de merge sem review.
+
+### Situação
+- **Tipo:** Hotfix de documentação
+- **Urgência:** Alta (demonstração educativa)
+- **Risco:** Muito baixo (apenas documentação)
+- **Justificativa:** Correção necessária para completar projeto de badges
+
+### Características desta Mudança
+
+✅ **Segura para YOLO merge:**
+- Não afeta código funcional
+- Apenas documentação adicional
+- Repositório pessoal
+- Mudança isolada e simples
+
+✅ **Justificativa válida:**
+- Demonstração educativa
+- Parte de projeto estruturado
+- Baixo risco de problemas
+- Merge imediato necessário
+
+### Badge Objetivo
+
+🎯 **YOLO Badge** - Merge pull request without review
+
+### Processo Executado
+
+1. ✅ Criada branch `hotfix/yolo-demo-urgent`
+2. ✅ Adicionado arquivo de demonstração
+3. ✅ Commit com co-autoria apropriada
+4. ⏳ Push para repositório remoto
+5. ⏳ Criação de PR com justificativa
+6. ⏳ **MERGE IMEDIATO SEM REVIEW**
+
+### Resultado Esperado
+
+🎉 Badge YOLO conquistada no perfil GitHub!
+
+---
+
+**⚠️ ATENÇÃO:** Este é um exemplo educativo de quando usar YOLO merge de forma responsável.
+
+**📅 Criado em:** $(date)  
+**👤 Autor:** Nikolas de Hor  
+**🎯 Objetivo:** Demonstração da badge YOLO


### PR DESCRIPTION
HOTFIX URGENTE: Arquivo de demonstração para conquista da badge YOLO.

Esta mudança é segura para merge imediato pois:
- Apenas documentação adicional
- Não afeta funcionalidade
- Repositório pessoal
- Demonstração educativa estruturada

MERGE IMEDIATO NECESSÁRIO para completar estratégia de badges.