### PR TITLE
docs: rewrite README as complete GitHub badges guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,121 +1,326 @@
-# GitHub Badges Mastery
+<div align="center">
 
-Repositorio dedicado para conquistar sistematicamente todas as insignias (badges) do GitHub.
+# 🏆 GitHub Badges Mastery
 
-## Status das Badges
+### O guia definitivo para conquistar TODAS as badges do GitHub
 
-| Badge | Status | Criterio Real | Como Conseguir |
-|-------|--------|---------------|----------------|
-| Pull Shark | **Conquistada** | 2+ PRs merged em repositorio de outra pessoa | PRs aceitos em repos de terceiros |
-| Quickdraw | **Conquistada** | Fechar issue/PR em <5min | Issue #4 fechada em <5min |
-| Pair Extraordinaire | Em progresso | PR merged com commits co-autorados | Commit com `Co-authored-by` em PR merged |
-| YOLO | Em progresso | Merge de PR sem code review | Criar PR e merge sem review |
-| Galaxy Brain | Pendente | 2 respostas aceitas em Discussions | Habilitar Discussions e responder perguntas |
-| Heart On Your Sleeve | Pendente | Reagir em Discussion posts | Habilitar Discussions e reagir a posts |
-| DevOps Guru | Em progresso | Workflow reutilizado por outro repo | Publicar GitHub Action reutilizavel |
+[![Stars](https://img.shields.io/github/stars/nikolasdehor/github-badges-mastery?style=for-the-badge&color=yellow)](https://github.com/nikolasdehor/github-badges-mastery/stargazers)
+[![Forks](https://img.shields.io/github/forks/nikolasdehor/github-badges-mastery?style=for-the-badge&color=blue)](https://github.com/nikolasdehor/github-badges-mastery/fork)
+[![Issues](https://img.shields.io/github/issues/nikolasdehor/github-badges-mastery?style=for-the-badge&color=green)](https://github.com/nikolasdehor/github-badges-mastery/issues)
 
-**Progresso: 2/7 conquistadas (29%)**
+---
 
-## Detalhes de Cada Badge
+**⭐ Se este guia te ajudou, dá uma estrela! Isso me ajuda a conquistar a badge Starstruck e mostra que o projeto é útil para a comunidade.**
 
-### Pull Shark - Conquistada
+[⭐ Dar Estrela](https://github.com/nikolasdehor/github-badges-mastery) · [🍴 Fazer Fork](https://github.com/nikolasdehor/github-badges-mastery/fork) · [💬 Discussions](https://github.com/nikolasdehor/github-badges-mastery/discussions)
 
-- **Criterio:** Ter pull requests aceitos (merged) em repositorios de outros usuarios
-- **Tiers:** Bronze (2), Silver (16), Gold (128), Diamond (1024)
-- **Status:** Bronze conquistado com PRs merged
+---
 
-### Quickdraw - Conquistada
+</div>
 
-- **Criterio:** Fechar um issue ou PR em menos de 5 minutos apos abri-lo
-- **Status:** Conquistada via issue #4
+## 📋 Todas as Badges do GitHub
 
-### Pair Extraordinaire - Em Progresso
+O GitHub tem **11 badges** no total. Algumas são conquistáveis hoje, outras estão em beta e 2 são legado (impossíveis de conseguir).
 
-- **Criterio:** Ter um PR merged que contenha commits com `Co-authored-by` no trailer
-- **Tiers:** Bronze (1), Silver (10), Gold (24), Diamond (48)
-- **Proximo passo:** Fazer merge de PR com commits co-autorados neste repo
-- **Formato do trailer:**
-  ```
-  Co-authored-by: Nome <email@example.com>
-  ```
+### ✅ Conquistáveis Agora
 
-### YOLO - Em Progresso
+| Badge | Como Conseguir | Níveis |
+|:------|:---------------|:-------|
+| 🦈 **Pull Shark** | Ter PRs mergeadas | x2 · x16 · x128 · x1024 |
+| 👯 **Pair Extraordinaire** | Co-autorar commits em PRs mergeadas | x1 · x10 · x24 · x48 |
+| 🧠 **Galaxy Brain** | Respostas aceitas em Discussions | x2 · x8 · x16 · x32 |
+| ⭐ **Starstruck** | Receber stars em um repo seu | 16 · 128 · 512 · 4096 |
+| 🤠 **YOLO** | Mergear PR sem code review | — |
+| ⚡ **Quickdraw** | Fechar issue/PR em menos de 5 min | — |
+| 💖 **Public Sponsor** | Patrocinar alguém via GitHub Sponsors | — |
 
-- **Criterio:** Fazer merge de um PR sem nenhum review
-- **Proximo passo:** Criar PR e mergear imediatamente sem review
-- **Nota:** Funciona apenas se o repo nao exigir review obrigatorio
+### 🧪 Em Beta (podem não aparecer para todos)
 
-### Galaxy Brain - Pendente
+| Badge | Como Conseguir |
+|:------|:---------------|
+| 💜 **Heart On Your Sleeve** | Reagir com emoji em Discussions |
+| 🌍 **Open Sourcerer** | PRs mergeadas em múltiplos repos públicos |
 
-- **Criterio:** Ter 2 respostas marcadas como "Accepted Answer" em GitHub Discussions
-- **Tiers:** Bronze (2), Silver (8), Gold (16), Diamond (32)
-- **Prerequisito:** Habilitar GitHub Discussions em Settings > General > Features
-- **Proximo passo:**
-  1. Ir em Settings > General > Features > marcar "Discussions"
-  2. Criar uma Discussion do tipo Q&A
-  3. Responder e marcar como "Accepted Answer"
+### 🏛️ Legado (não dá mais para conseguir)
 
-### Heart On Your Sleeve - Pendente
+| Badge | O que era |
+|:------|:----------|
+| 🧊 **Arctic Code Vault Contributor** | Contribuiu em repos arquivados no Arctic Code Vault (2020) |
+| 🚀 **Mars 2020 Helicopter Contributor** | Contribuiu em repos usados na missão Mars Helicopter da NASA |
 
-- **Criterio:** Reagir com emoji a posts em GitHub Discussions
-- **Prerequisito:** GitHub Discussions habilitado
-- **Proximo passo:** Reagir a Discussion posts com emojis
+---
 
-### DevOps Guru - Em Progresso
+## 🎯 Guia Passo a Passo de Cada Badge
 
-- **Criterio:** Ter um workflow GitHub Actions que seja reutilizado por outro repositorio
-- **Proximo passo:** Publicar uma GitHub Action reutilizavel ou ter workflow adotado
-- **Nota:** 8 workflows locais estao configurados, mas a badge exige uso externo
+### 🦈 Pull Shark
 
-## Estrutura do Projeto
+> Ter Pull Requests aceitas (merged) em repositórios.
+
+**Passo a passo:**
+1. Encontre um repositório open source que aceite contribuições
+2. Faça um fork do repositório
+3. Crie uma branch e faça suas alterações (correção de typo, melhoria de docs, bugfix)
+4. Abra um Pull Request e aguarde o merge
+5. Com **2 PRs mergeadas** você já ganha a badge!
+
+**Dica rápida:** Comece com contribuições simples — corrigir erros de digitação em READMEs, melhorar documentação, ou adicionar traduções. Muitos repos têm issues marcadas como `good first issue`.
+
+| Nível | PRs Mergeadas |
+|:------|:-------------|
+| 🥉 Bronze | 2 |
+| 🥈 Silver | 16 |
+| 🥇 Gold | 128 |
+| 💎 Diamond | 1024 |
+
+---
+
+### 👯 Pair Extraordinaire
+
+> Ter commits co-autorados em PRs que foram mergeadas.
+
+**Passo a passo:**
+1. Trabalhe em conjunto com outro desenvolvedor (ou use este repo!)
+2. Nos commits, adicione o trailer de co-autoria:
+   ```
+   git commit -m "feat: minha feature
+
+   Co-authored-by: Nome do Parceiro <email@example.com>"
+   ```
+3. Abra um PR com esses commits
+4. Faça o merge — a badge aparece em algumas horas!
+
+**Usando este repo:**
+1. Faça um fork deste repositório
+2. Clone o fork: `git clone https://github.com/SEU-USER/github-badges-mastery.git`
+3. Faça um commit com co-autoria:
+   ```bash
+   git commit --allow-empty -m "feat: pair programming practice
+
+   Co-authored-by: nikolasdehor <nikolasdehor79@gmail.com>"
+   ```
+4. Push e abra um PR no SEU fork
+5. Faça o merge do PR
+
+| Nível | PRs com Co-autoria |
+|:------|:------------------|
+| 🥉 Bronze | 1 |
+| 🥈 Silver | 10 |
+| 🥇 Gold | 24 |
+| 💎 Diamond | 48 |
+
+---
+
+### 🧠 Galaxy Brain
+
+> Ter respostas marcadas como "Accepted Answer" em GitHub Discussions.
+
+**Passo a passo:**
+1. Vá em **Settings > General > Features** e habilite **Discussions**
+2. Na aba Discussions, crie uma categoria do tipo **Q&A** (se não existir)
+3. Crie uma pergunta na categoria Q&A
+4. Responda a pergunta com outra conta (ou peça para alguém responder)
+5. Marque a resposta como **"Accepted Answer"** (ícone de check ✓)
+6. Repita — precisa de **2 respostas aceitas** para a badge!
+
+**Dica:** Você pode criar Discussions neste repo! Vá na [aba Discussions](https://github.com/nikolasdehor/github-badges-mastery/discussions) e participe.
+
+| Nível | Respostas Aceitas |
+|:------|:-----------------|
+| 🥉 Bronze | 2 |
+| 🥈 Silver | 8 |
+| 🥇 Gold | 16 |
+| 💎 Diamond | 32 |
+
+---
+
+### ⭐ Starstruck
+
+> Ter um repositório com muitas estrelas.
+
+**Passo a passo:**
+1. Crie um repositório público com conteúdo útil
+2. Escreva um bom README (como este!)
+3. Compartilhe em comunidades: Reddit, Twitter/X, Dev.to, Discord
+4. Quando atingir **16 stars**, a badge é sua!
+
+**Como você pode ajudar:** Se este guia foi útil, [dá uma estrela](https://github.com/nikolasdehor/github-badges-mastery)! Cada star conta.
+
+| Nível | Estrelas |
+|:------|:--------|
+| 🥉 Bronze | 16 |
+| 🥈 Silver | 128 |
+| 🥇 Gold | 512 |
+| 💎 Diamond | 4096 |
+
+---
+
+### 🤠 YOLO
+
+> Mergear um Pull Request sem nenhum code review.
+
+**Passo a passo:**
+1. Certifique-se de que o repositório **não tem** branch protection com review obrigatório
+2. Crie uma branch: `git checkout -b minha-feature`
+3. Faça uma alteração e commit
+4. Push: `git push -u origin minha-feature`
+5. Abra um PR no GitHub
+6. Clique em **"Merge pull request"** imediatamente, sem pedir review
+7. Badge conquistada!
+
+**Usando este repo:**
+1. Faça um fork
+2. Crie uma branch, faça uma alteração, abra um PR
+3. Mergee sem pedir review — pronto!
+
+---
+
+### ⚡ Quickdraw
+
+> Fechar uma issue ou PR em menos de 5 minutos após abrir.
+
+**Passo a passo:**
+1. Abra uma nova Issue no repositório
+2. Feche a Issue **imediatamente** (em menos de 5 minutos)
+3. Badge conquistada!
+
+**Usando este repo:**
+1. Vá em [Issues](https://github.com/nikolasdehor/github-badges-mastery/issues)
+2. Crie uma issue (ex: "Teste Quickdraw")
+3. Feche imediatamente
+4. Pronto!
+
+---
+
+### 💖 Public Sponsor
+
+> Patrocinar um desenvolvedor ou projeto open source via GitHub Sponsors.
+
+**Passo a passo:**
+1. Encontre um desenvolvedor ou projeto que aceite sponsors
+2. Vá no perfil dele e clique em **"Sponsor"**
+3. Escolha um valor (pode ser **$1/mês** ou até one-time)
+4. Complete o pagamento
+5. Badge conquistada!
+
+**Dica:** Você pode cancelar a qualquer momento, mas a badge fica para sempre.
+
+---
+
+### 💜 Heart On Your Sleeve (Beta)
+
+> Reagir com emoji a posts em GitHub Discussions.
+
+**Passo a passo:**
+1. Habilite Discussions no repositório (Settings > General > Features)
+2. Vá em uma Discussion
+3. Reaja com qualquer emoji (👍 ❤️ 🚀 etc.)
+4. A badge pode demorar para aparecer por estar em beta
+
+---
+
+### 🌍 Open Sourcerer (Beta)
+
+> Ter PRs mergeadas em múltiplos repositórios públicos.
+
+**Passo a passo:**
+1. Contribua com PRs em **diferentes** repositórios open source
+2. Aguarde os merges
+3. A badge é atribuída automaticamente (está em beta)
+
+---
+
+## 🚀 Quick Start — Conquiste suas Primeiras Badges em Minutos
+
+```bash
+# 1. Faça um fork deste repo (clique no botão "Fork" acima)
+
+# 2. Clone o fork
+git clone https://github.com/SEU-USER/github-badges-mastery.git
+cd github-badges-mastery
+
+# 3. Conquiste YOLO — crie branch, altere algo, PR e merge sem review
+git checkout -b minha-badge
+echo "# Minha conquista" >> CONQUISTAS.md
+git add CONQUISTAS.md
+git commit -m "feat: minha primeira conquista"
+git push -u origin minha-badge
+# Abra PR no GitHub e mergee sem review → 🤠 YOLO!
+
+# 4. Conquiste Quickdraw — abra e feche uma Issue em <5min → ⚡
+
+# 5. Conquiste Pair Extraordinaire — faça commit com co-autoria
+git checkout -b pair-practice
+git commit --allow-empty -m "feat: pair programming
+
+Co-authored-by: nikolasdehor <nikolasdehor79@gmail.com>"
+git push -u origin pair-practice
+# Abra PR e mergee → 👯
+
+# 6. Dá uma ⭐ neste repo para me ajudar com Starstruck!
+```
+
+---
+
+## 📊 Meu Progresso
+
+| Badge | Status |
+|:------|:-------|
+| 🦈 Pull Shark | ✅ Conquistada (x2) |
+| 👯 Pair Extraordinaire | ✅ Conquistada |
+| 🤠 YOLO | ✅ Conquistada |
+| ⚡ Quickdraw | ✅ Conquistada |
+| 💜 Heart On Your Sleeve | ✅ Conquistada |
+| 🧠 Galaxy Brain | ✅ Conquistada |
+| ⭐ Starstruck | 🔄 Em progresso — me ajude com uma ⭐! |
+
+---
+
+## 🤝 Como Contribuir
+
+Toda contribuição é bem-vinda! Ao contribuir, você também pratica para suas próprias badges.
+
+1. **Fork** este repositório
+2. Crie uma **branch** para sua feature
+3. Faça suas alterações
+4. Abra um **Pull Request**
+5. **⭐ Dê uma estrela** se o projeto te ajudou!
+
+Veja o [CONTRIBUTING.md](CONTRIBUTING.md) para mais detalhes.
+
+---
+
+## 📁 Estrutura do Projeto
 
 ```
 github-badges-mastery/
 ├── .github/
-│   ├── workflows/           # 8 GitHub Actions workflows
-│   ├── ISSUE_TEMPLATE/      # Templates para issues
-│   └── DISCUSSION_TEMPLATE/ # Templates para discussions
+│   ├── workflows/           # GitHub Actions para automação
+│   ├── ISSUE_TEMPLATE/      # Templates de issues
+│   └── DISCUSSION_TEMPLATE/ # Templates de discussions
 ├── src/
-│   └── index.js             # Badge tracker principal
+│   └── index.js             # Badge tracker
 ├── tests/
-│   └── index.test.js        # 18 testes unitarios
-├── scripts/                 # Scripts de automacao
-├── docs/                    # Documentacao detalhada
+│   └── index.test.js        # Testes unitários
+├── scripts/                 # Scripts de automação
+├── docs/                    # Documentação extra
 └── package.json
 ```
 
-## Como Usar
+---
 
-```bash
-# Ver status das badges
-npm start
+<div align="center">
 
-# Rodar testes (18 testes)
-npm test
+### ⭐ Gostou? Dá uma estrela!
 
-# Build
-npm run build
-```
+Se este guia te ajudou a entender ou conquistar badges do GitHub, **dá uma estrela neste repositório**!
 
-## Workflows Disponiveis
+Cada ⭐ me aproxima da badge **Starstruck** e mostra que este conteúdo é útil.
 
-| Workflow | Comando | Proposito |
-|----------|---------|-----------|
-| CI/CD Pipeline | `gh workflow run ci.yml` | Testes + build |
-| YOLO Merge | `gh workflow run yolo-merge.yml` | Merge direto sem review |
-| Quickdraw Issues | `gh workflow run quickdraw-issues.yml` | Criar issues automaticamente |
-| Pair Programming | `gh workflow run pair-programming.yml` | Commits co-autorados |
-| Badge Monitor | `gh workflow run badge-monitor.yml` | Monitorar progresso |
+[![Star this repo](https://img.shields.io/badge/⭐_Dar_Estrela-yellow?style=for-the-badge)](https://github.com/nikolasdehor/github-badges-mastery)
+[![Fork this repo](https://img.shields.io/badge/🍴_Fazer_Fork-blue?style=for-the-badge)](https://github.com/nikolasdehor/github-badges-mastery/fork)
 
-## Acoes Manuais Necessarias
+---
 
-Algumas badges precisam de acoes manuais no GitHub:
+**Feito com 💪 por [@nikolasdehor](https://github.com/nikolasdehor)**
 
-1. **Galaxy Brain + Heart On Your Sleeve:** Habilitar Discussions em Settings > General > Features
-2. **YOLO:** Desabilitar branch protection rules (se houver) para permitir merge sem review
-3. **Pair Extraordinaire:** Fazer merge do PR com commits co-autorados
-4. **DevOps Guru:** Publicar workflow como GitHub Action reutilizavel
-
-## Licenca
-
-MIT
+</div>


### PR DESCRIPTION
Rewrote the entire README to serve as a definitive guide for all 11 GitHub badges. Includes step-by-step tutorials for each badge, correct badge info (removed fictional DevOps Guru), tier tables, quick start section, prominent star/fork CTAs, and updated personal progress tracker.

Co-authored-by: Nikolas de Hor <nikolasdehor79@gmail.com>

https://claude.ai/code/session_01JY9jdjLgAaYz1vk9LSVmLw